### PR TITLE
Add tests for aiostd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Run lint
       run: |
         make lint
-    # - name: Run tests
-    #   run: |
-    #     pytest
+    - name: Run tests
+      run: |
+        pytest

--- a/tests/test_aiostd.py
+++ b/tests/test_aiostd.py
@@ -1,0 +1,49 @@
+import asyncio
+import io
+import pytest
+import aiostd
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.mark.asyncio
+async def test_open_io_stream_reader(event_loop):
+    input_data = "test input\n"
+    reader = io.StringIO(input_data)
+
+    stream_reader = await aiostd.open_io_stream_reader(reader, loop=event_loop)
+    result = await stream_reader.readline()
+
+    assert result == input_data
+
+
+@pytest.mark.asyncio
+async def test_open_io_stream_writer(event_loop):
+    output = io.StringIO()
+
+    stream_writer = await aiostd.open_io_stream_writer(output, loop=event_loop)
+    test_data = "test output\n"
+    stream_writer.write(test_data)
+    await stream_writer.drain()
+
+    assert output.getvalue() == test_data
+
+
+@pytest.mark.asyncio
+async def test_open_io_stream(event_loop):
+    input_data = "test input\n"
+    reader = io.StringIO(input_data)
+    output = io.StringIO()
+
+    stream_reader, stream_writer = await aiostd.open_io_stream(reader, output, loop=event_loop)
+    result = await stream_reader.readline()
+    stream_writer.write(result)
+    await stream_writer.drain()
+
+    assert result == input_data
+    assert output.getvalue() == input_data


### PR DESCRIPTION
Add tests for `aiostd` functions and update CI workflow to run tests.

* **Add tests**
  - Add `tests/test_aiostd.py` to test `open_io_stream_reader`, `open_io_stream_writer`, and `open_io_stream`.
  - Use `pytest` fixtures to set up and tear down the test environment.
* **Update CI workflow**
  - Uncomment the `Run tests` step in `.github/workflows/ci.yml`.
  - Use `pytest` to run the tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aliev/aiostd?shareId=272c74b9-6750-4338-a714-48389b5b9fcf).